### PR TITLE
New csproj for Mac OS X support

### DIFF
--- a/LilyPath.sln
+++ b/LilyPath.sln
@@ -5,6 +5,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LilyPath", "LilyPath\LilyPa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LilyPathDemo", "LilyPathDemo\LilyPathDemo.csproj", "{858F90E5-7897-4FF0-95FA-5229C0D32B88}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LilyPath.MacOS", "LilyPath\LilyPath.MacOS.csproj", "{788B3CC4-4CC7-41D1-86C3-3439F3903C52}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,24 @@ Global
 		{2921C80E-2B58-41C4-B834-B92A478C3631}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
 		{2921C80E-2B58-41C4-B834-B92A478C3631}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{2921C80E-2B58-41C4-B834-B92A478C3631}.Release|x86.ActiveCfg = Release|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Debug|x86.Build.0 = Debug|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Release.Android|Any CPU.ActiveCfg = Release|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Release.Android|Any CPU.Build.0 = Release|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Release.Android|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Release.Android|Mixed Platforms.Build.0 = Release|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Release.Android|x86.ActiveCfg = Release|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Release.Android|x86.Build.0 = Release|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Release|Any CPU.Build.0 = Release|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Release|x86.ActiveCfg = Release|Any CPU
+		{788B3CC4-4CC7-41D1-86C3-3439F3903C52}.Release|x86.Build.0 = Release|Any CPU
 		{858F90E5-7897-4FF0-95FA-5229C0D32B88}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{858F90E5-7897-4FF0-95FA-5229C0D32B88}.Debug|Mixed Platforms.ActiveCfg = Debug|x86
 		{858F90E5-7897-4FF0-95FA-5229C0D32B88}.Debug|Mixed Platforms.Build.0 = Debug|x86
@@ -48,6 +68,9 @@ Global
 		{858F90E5-7897-4FF0-95FA-5229C0D32B88}.Release|Mixed Platforms.Build.0 = Release|x86
 		{858F90E5-7897-4FF0-95FA-5229C0D32B88}.Release|x86.ActiveCfg = Release|x86
 		{858F90E5-7897-4FF0-95FA-5229C0D32B88}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = LilyPath\LilyPath.csproj
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/LilyPath/LilyPath.MacOS.csproj
+++ b/LilyPath/LilyPath.MacOS.csproj
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProductVersion>10.0.0</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{788B3CC4-4CC7-41D1-86C3-3439F3903C52}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>LilyPath.MacOS</RootNamespace>
+    <AssemblyName>LilyPath.MacOS</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <ItemGroup>
+    <Folder Include="LilyPath\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Brush.cs" />
+    <Compile Include="DrawBatch.cs" />
+    <Compile Include="Enums.cs" />
+    <Compile Include="GraphicsPath.cs" />
+    <Compile Include="PathBuilder.cs" />
+    <Compile Include="Pen.cs" />
+    <Compile Include="SolidColorBrush.cs" />
+    <Compile Include="TextureBrush.cs" />
+    <Compile Include="Triangulator.cs" />
+    <Compile Include="Brushes\CheckerBrush.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="MonoGame.Framework, Version=3.0.1.0, Culture=neutral">
+      <Private>False</Private>
+    </Reference>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
The original csproj references assemblies that won't work in Mac OS X.

To remedy that, this new csproj references MacOS-specific implementations of the required namespaces.
